### PR TITLE
Enable optional generation of cpu profiles for each test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Compares actual vs expected for all test cases
 -   `shouldError` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function to convert test case into a boolean, if the case should result in an error (optional, default `(testCase,index,testSpec)=>false`)
 -   `shouldSkip` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function to convert test case into a boolean, if the case should be skipped (optional, default `(testCase,index,testSpec)=>false`)
 -   `expectFunc` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function to run expectations against expected and actual output (optional, default `(testCase,expect,expected,actual)=>expect(actual).to.be.equal(expected)`)
+
+## Profiling
+
+Set env variable GEN_PROFILE_DIR with path to directory where you wish your cpu profiles to be generated.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "bn.js": "^4.11.8",
     "camelcase": "^5.3.1",
     "chai": "^4.2.0",
-    "js-yaml": "^3.13.1"
+    "js-yaml": "^3.13.1",
+    "v8-profiler-next": "^1.1.0"
   },
   "devDependencies": {
     "documentation": "^10.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,6 +2317,11 @@ nan@^2.12.1:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
 
+nan@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -3460,6 +3465,13 @@ use@^3.1.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+v8-profiler-next@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/v8-profiler-next/-/v8-profiler-next-1.1.0.tgz#1ba655d9e0683b7beec6aec2282ed84e355e2641"
+  integrity sha512-Ql7msIrxQRJWIi4rXHYyeW0C+yYehunS5fXaZowm/Tb3RY6rMg3fPwghTdj/s0KOcv3OtDHvf1C5x9Ll+SlBzg==
+  dependencies:
+    nan "^2.14.0"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
- if env variable is set it will generate cpu profiles in desired directory


Usage in Lodestar repo:

`GEN_PROFILE_DIR=$PWD mocha -r ./.babel-register 'test/spec/sanity/blocks/blocksanity_s_mainnet.test.ts'`

To view results:
```bash
npm i -g ox
0x --visualize-cpu-profile ./0\ -\ attestation-1561705313935.cpuprofile
```